### PR TITLE
Restore request candidate's operation which returns partial policy co…

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -37,5 +37,11 @@ type Manager interface {
 	// the error.
 	FindRequestCandidates(r *Request) (Policies, error)
 
+	// FindPoliciesForSubject returns full policy contents found for the subject.
+	// FindRequestCandidates, however, does not return full policy contents.
+	FindPoliciesForSubject(r *Request) (Policies, error)
+
+	// FindPoliciesForResource returns full policy contents found for the resource.
+	// FindRequestCandidates, however, does not return full policy contents.
 	FindPoliciesForResource(r *Request) (Policies, error)
 }

--- a/manager/memory/manager_memory.go
+++ b/manager/memory/manager_memory.go
@@ -105,17 +105,10 @@ func (m *MemoryManager) FindRequestCandidates(r *Request) (Policies, error) {
 	return ps, nil
 }
 
-// FindPoliciesForResource returns candidates that could match the request object. It either returns
-// a set that exactly matches the request, or a superset of it. If an error occurs, it returns nil and
-// the error.
+func (m *MemoryManager) FindPoliciesForSubject(r *Request) (Policies, error) {
+	return m.FindRequestCandidates(r)
+}
+
 func (m *MemoryManager) FindPoliciesForResource(r *Request) (Policies, error) {
-	m.RLock()
-	defer m.RUnlock()
-	ps := make(Policies, len(m.Policies))
-	var count int
-	for _, p := range m.Policies {
-		ps[count] = p
-		count++
-	}
-	return ps, nil
+	return m.FindRequestCandidates(r)
 }

--- a/manager/sql/databases.go
+++ b/manager/sql/databases.go
@@ -12,6 +12,7 @@ type Statements struct {
 	QueryInsertPolicySubjects     string
 	QueryInsertPolicySubjectsRel  string
 	QueryRequestCandidates        string
+	QueryPoliciesForSubject       string
 	QueryPoliciesForResource      string
 }
 
@@ -147,7 +148,30 @@ var Migrations = map[string]Statements{
 		QueryInsertPolicyResourcesRel: `INSERT INTO ladon_policy_resource_rel (policy, resource) SELECT $1::varchar, $2::varchar WHERE NOT EXISTS (SELECT 1 FROM ladon_policy_resource_rel WHERE policy = $1 AND resource = $2)`,
 		QueryInsertPolicySubjects:     `INSERT INTO ladon_subject (id, template, compiled, has_regex) SELECT $1::varchar, $2, $3, $4 WHERE NOT EXISTS (SELECT 1 FROM ladon_subject WHERE id = $1)`,
 		QueryInsertPolicySubjectsRel:  `INSERT INTO ladon_policy_subject_rel (policy, subject) SELECT $1::varchar, $2::varchar WHERE NOT EXISTS (SELECT 1 FROM ladon_policy_subject_rel WHERE policy = $1 AND subject = $2)`,
-		QueryRequestCandidates: queryBase + `
+		QueryRequestCandidates: `
+SELECT
+	p.id,
+	p.effect,
+	p.conditions,
+	p.description,
+	subject.template AS subject,
+	resource.template AS resource,
+	action.template AS action
+FROM
+	ladon_policy AS p
+
+	INNER JOIN ladon_policy_subject_rel AS rs ON rs.policy = p.id
+	LEFT JOIN ladon_policy_action_rel AS ra ON ra.policy = p.id
+	LEFT JOIN ladon_policy_resource_rel AS rr ON rr.policy = p.id
+
+	INNER JOIN ladon_subject AS subject ON rs.subject = subject.id
+	LEFT JOIN ladon_action AS action ON ra.action = action.id
+	LEFT JOIN ladon_resource AS resource ON rr.resource = resource.id
+WHERE
+	(subject.has_regex IS NOT TRUE AND subject.template = $1)
+	OR
+	(subject.has_regex IS TRUE AND $2 ~ subject.compiled)`,
+		QueryPoliciesForSubject: queryBase + `
 WHERE p.id IN
 	(SELECT lp.id FROM ladon_policy AS lp
 		INNER JOIN ladon_policy_subject_rel AS lps ON lps.policy = lp.id
@@ -193,7 +217,30 @@ WHERE p.id IN
 		QueryInsertPolicyResourcesRel: `INSERT IGNORE INTO ladon_policy_resource_rel (policy, resource) VALUES(?,?)`,
 		QueryInsertPolicySubjects:     `INSERT IGNORE INTO ladon_subject (id, template, compiled, has_regex) VALUES(?,?,?,?)`,
 		QueryInsertPolicySubjectsRel:  `INSERT IGNORE INTO ladon_policy_subject_rel (policy, subject) VALUES(?,?)`,
-		QueryRequestCandidates: queryBase + `
+		QueryRequestCandidates: `
+SELECT
+	p.id,
+	p.effect,
+	p.conditions,
+	p.description,
+	subject.template AS subject,
+	resource.template AS resource,
+	action.template AS action
+FROM
+	ladon_policy AS p
+
+	INNER JOIN ladon_policy_subject_rel AS rs ON rs.policy = p.id
+	LEFT JOIN ladon_policy_action_rel AS ra ON ra.policy = p.id
+	LEFT JOIN ladon_policy_resource_rel AS rr ON rr.policy = p.id
+
+	INNER JOIN ladon_subject AS subject ON rs.subject = subject.id
+	LEFT JOIN ladon_action AS action ON ra.action = action.id
+	LEFT JOIN ladon_resource AS resource ON rr.resource = resource.id
+WHERE
+	(subject.has_regex = 0 AND subject.template = ?)
+	OR
+	(subject.has_regex = 1 AND ? REGEXP BINARY subject.compiled)`,
+		QueryPoliciesForSubject: queryBase + `
 WHERE p.id IN
 	(SELECT lp.id FROM ladon_policy AS lp
 		INNER JOIN ladon_policy_subject_rel AS lps ON lps.policy = lp.id

--- a/manager/sql/manager_sql.go
+++ b/manager/sql/manager_sql.go
@@ -200,6 +200,22 @@ func (s *SQLManager) FindRequestCandidates(r *Request) (Policies, error) {
 	return scanRows(rows)
 }
 
+// FindPoliciesForSubject returns full policy contents found for the subject
+func (s *SQLManager) FindPoliciesForSubject(r *Request) (Policies, error) {
+	query := Migrations[s.database].QueryPoliciesForSubject
+
+	rows, err := s.db.Query(s.db.Rebind(query), r.Subject, r.Subject)
+	if err == sql.ErrNoRows {
+		return nil, NewErrResourceNotFound(err)
+	} else if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	defer rows.Close()
+
+	return scanRows(rows)
+}
+
+// FindPoliciesForResource returns full policy contents found for the resource.
 func (s *SQLManager) FindPoliciesForResource(r *Request) (Policies, error) {
 	query := Migrations[s.database].QueryPoliciesForResource
 


### PR DESCRIPTION
…ntents

I previously changed `FindRequestCandidates` to return full policy contents, but I think the query would be more expensive and it is used by all token allowed requests.

So I restored the original query for FindRequestCandidates and added a separate `FindPoliciesForSubject` function that returns full policies.

- [x] @abdulchaudhrycoupa 